### PR TITLE
Engine: ability to turn off rule scoping.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ define(['nbd/Class', 'nbd/util/extend', './src/Engine'], function(Class, extend,
   'use strict';
 
   var Focss = Class.extend({
-    init: function(root, extensions) {
-      this.engine = new Engine(root);
+    init: function(root, extensions, scoped) {
+      scoped = scoped === undefined ? true : false;
+      this.engine = new Engine(root, scoped);
       extend(this.engine.extensions, extensions);
     },
 

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -13,15 +13,19 @@ define([
   genId.i = 1;
 
   var Engine = Class.extend({
-    init: function(root) {
+    init: function(root, scoped) {
       var target = root || document.body;
       this.rules = [];
       this.extensions = Object.create(this.extensions);
       this.style = document.createElement('style');
-      this.style.setAttribute('scoped', 'scoped');
+
+      if (scoped) {
+        this.style.setAttribute('scoped', 'scoped');
+      }
+
       target.insertBefore(this.style, target.firstChild);
 
-      if (compat.scopeSupported || target === document.body) {
+      if (!scoped || compat.scopeSupported || target === document.body) {
         this._prefix = '';
       }
       else {

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -8,6 +8,7 @@ define([
 ], function(Class, extend, diff, css, expression, specificity) {
   'use strict';
   var computed = /\$\{([^\}]*?)\}/ig;
+  var scoped = /^\w*:scope/;
 
   function lookup(obj, prop) {
     return obj && obj[prop];
@@ -38,7 +39,7 @@ define([
       if (!prefix) { return this.computedSelector || this.selector; }
 
       return this.specificity.map(function(part) {
-        return prefix + part.selector;
+        return scoped.test(part.selector) ? part.selector : prefix + part.selector;
       }, this).join(',');
     },
 


### PR DESCRIPTION
Turning off rule scoping allows rules to impact the entirety of the DOM,
which may be necessary (e.g. :root or html selector)