### PR TITLE
Rule: moving diff check to post process

### DIFF
--- a/src/Engine.js
+++ b/src/Engine.js
@@ -44,8 +44,9 @@ define([
     },
 
     _process: function(rule, i) {
-      rule.process(this._state, this.extensions);
-      var selector = rule.getSelector(this._prefix);
+      var result = rule.process(this._state, this.extensions),
+          selector = rule.getSelector(this._prefix);
+
       // Selector has changed
       if (selector !== this.cssRules[i].selectorText) {
         if (compat.changeSelectorTextAllowed) {
@@ -56,7 +57,11 @@ define([
           this.sheet.insertRule(rule.getSelector(this._prefix) + '{}', i);
         }
       }
-      css.apply(this.cssRules[i], rule.result);
+
+      // Results have changed
+      if (result) {
+        css.apply(this.cssRules[i], result);
+      }
     },
 
     insert: function(selector, spec) {

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -44,19 +44,15 @@ define([
     },
 
     process: function(data, extensions) {
-      var artifacts = Object.keys(this.artifacts)
-      .reduce(function archaeology(artifacts, path) {
-        artifacts[path] = path.split('.').reduce(lookup, data);
-        return artifacts;
-      }, {});
+      // First find out the new results
+      this._process(data, extensions);
 
-      var different = !this._lastArtifacts ||
-        Object.keys(diff(artifacts, this._lastArtifacts)).length;
+      // Then diff the results with last results
+      var different = !this._lastResult ||
+        Object.keys(diff(this.result, this._lastResult)).length;
 
-      if (different) {
-        this._process(data, extensions);
-      }
-      this._lastArtifacts = artifacts;
+      this._lastResult = this.result;
+      return different ? this.result : null;
     },
 
     _process: function(data, extensions) {

--- a/test/unit/src/Rule.js
+++ b/test/unit/src/Rule.js
@@ -78,6 +78,20 @@ define(['src/Rule'], function(Rule) {
         expect(rule.result).toEqual({ foo: 'baz' });
       });
 
+      it('calculates non-idempotent extensions', function() {
+        rule = new Rule('.extended', {
+          foo: 'bar()'
+        });
+
+        var bar = jasmine.createSpy('extension').and.returnValues('bar', 'baz');
+
+        rule.process({}, { bar: bar });
+        expect(rule.result).toEqual({ foo: 'bar' });
+
+        rule.process({}, { bar: bar });
+        expect(rule.result).toEqual({ foo: 'baz' });
+      });
+
       it('ignores missing extensions', function() {
         rule = new Rule('.extended', {
           foo: 'bar()'


### PR DESCRIPTION
Instead of doing a diff check on the input object (assumption of
idempotence), we do the diff check on the result object instead, which
guarantees us correctness in case the rule body is not idempotent.

This still saves us the call to css.apply(), which is the slowest part.