### PR TITLE
Pseudo-element causes empty body

### DIFF
--- a/src/Engine.js
+++ b/src/Engine.js
@@ -55,12 +55,14 @@ define([
         else {
           this.sheet.deleteRule(i);
           this.sheet.insertRule(rule.getSelector(this._prefix) + '{}', i);
+          // If the rule has been replaced, we must re-apply the rule body
+          result = true;
         }
       }
 
       // Results have changed
       if (result) {
-        css.apply(this.cssRules[i], result);
+        css.apply(this.cssRules[i], rule.result);
       }
     },
 

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -14,12 +14,19 @@ define([
     return obj && obj[prop];
   }
 
+  // CSS3 introduces the double colon syntax for pseudos
+  var css2PseudoEl = /:(after|before|first-letter|first-line)|::/g;
+  function prefixPseudo(a, b) { return b ? ':' + a : a; }
+  function normalizePseudoElement(selector) {
+    return selector.replace(css2PseudoEl, prefixPseudo);
+  }
+
   var Rule = Class.extend({
     init: function(selector, spec) {
       if (typeof selector !== 'string') {
         throw new TypeError('selector must be a string.');
       }
-      this.selector = selector;
+      this.selector = normalizePseudoElement(selector);
 
       this.body = expression.compileSpec(spec);
       this.artifacts = extend({}, this.body.artifacts);

--- a/test/behavior/dynamic.js
+++ b/test/behavior/dynamic.js
@@ -49,6 +49,19 @@ define(['index'], function(Focss) {
         fox.process({ foo: 'baz', width: 40 });
         expect(css(el, 'max-width')).toBe('none');
       });
+
+      it('maintains styles when selector changes', function() {
+        var el = affix('div.bar.baz');
+        fox.insert('.${foo}', {
+          'max-width': 'width'
+        });
+
+        fox.process({ foo: 'bar', width: 100 });
+        expect(css(el, 'max-width')).toBe('100px');
+
+        fox.process({ foo: 'baz', width: 100 });
+        expect(css(el, 'max-width')).toBe('100px');
+      });
     });
 
     describe('DOM mutation', function() {

--- a/test/unit/src/Rule.js
+++ b/test/unit/src/Rule.js
@@ -7,6 +7,12 @@ define(['src/Rule'], function(Rule) {
       expect(rule).toBeDefined();
     });
 
+    it('normalizes CSS2 pseudo-element selectors', function() {
+      rule = new Rule('section:after, section:before, section:first-line, section:first-letter', {});
+
+      expect(rule.selector).toBe('section::after, section::before, section::first-line, section::first-letter');
+    });
+
     it('needs a selector and body', function() {
       expect(function() {
         rule = new Rule();


### PR DESCRIPTION
Rule body would be emptied out on browsers that do not support in-place rule selector replacement.
This is triggered by pseudo-element selectors written in CSS2 style (e.g. `:before`) to not match the browser reported selector.