### PR TITLE
Refactor: Move trace creation into Rule instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ var Focss = Class.extend({
 })
 .mixin({
   get traces() {
-    return this.engine.traces;
+    return this.engine.getTraces();
   }
 });
 


### PR DESCRIPTION
fixes https://github.com/adobe-community/issues/issues/10947

Moving the trace creation logic into the instantiation of Rules frees us up to extract out a RuleList class, which we want for clarity and to clean up some of the weird things I had to do in my previous  PR.