### PR TITLE
Refactor: Remove Rule as static class property of Engine

### DIFF
--- a/src/Engine.js
+++ b/src/Engine.js
@@ -241,7 +241,7 @@ Engine = Class.extend({
     var artifacts = {};
     var expr;
 
-    while ((expr = this.constructor.Rule.computed.exec(selector)) !== null) {
+    while ((expr = Rule.computed.exec(selector)) !== null) {
       Object.assign(artifacts, expression.parse(expr[1]).artifacts);
     }
 
@@ -306,7 +306,7 @@ Engine = Class.extend({
   },
 
   _insertRule(ruleData, { rules }) {
-    const rule = new this.constructor.Rule(ruleData);
+    const rule = new Rule(ruleData);
     const i = this.rules.length;
 
     if (hasDom) {
@@ -328,7 +328,6 @@ Engine = Class.extend({
     Number
   }
 }, {
-  Rule,
   displayName: 'FocssEngine'
 });
 

--- a/test/behavior/toggleSelectors.js
+++ b/test/behavior/toggleSelectors.js
@@ -143,19 +143,19 @@ describe('toggleSelectors rules', function() {
       this._el = affix('div.bar[data-id="-1"]');
       this._el2 = affix('div.bar[data-id="4"]');
       this._el3 = affix('div.bar[data-id="5"]');
-      this._fox.process({
-        foo: [
-          { id: -1, width: 100 },
-          { id: 4, width: 200 },
-          { id: 5, width: 300 }
-        ]
-      });
     });
 
     describe('with a forEach selector', function() {
       beforeEach(function() {
         this._fox.insert('%forEach(foo, .bar[data-id="%id%"]:hover)', {
           'max-width': 'width'
+        });
+        this._fox.process({
+          foo: [
+            { id: -1, width: 100 },
+            { id: 4, width: 200 },
+            { id: 5, width: 300 }
+          ]
         });
       });
 

--- a/test/unit/src/Engine.js
+++ b/test/unit/src/Engine.js
@@ -1,4 +1,5 @@
 import Engine from '../../../src/Engine';
+import Rule from '../../../src/Rule';
 
 describe('Engine', function() {
   beforeEach(function() {
@@ -24,32 +25,29 @@ describe('Engine', function() {
 
   describe('#process()', function() {
     it('runs individual rule.process()', function() {
-      spyOn(Engine, 'Rule')
-      .and.returnValue(jasmine.createSpyObj('rule', ['process', 'getSelector']));
-
-      var payload = {
+      spyOn(Rule.prototype, 'process');
+      const payload = {
         foo: 'bar'
       };
-      var rule = this._engine.insert('selector', {});
+      const rule = this._engine.insert('selector', {});
       this._engine.process(payload);
       expect(rule.process).toHaveBeenCalledWith(jasmine.objectContaining(payload), jasmine.anything());
     });
 
     it('merges variable data with user data', function() {
-      var payload = {
+      spyOn(Rule.prototype, 'process');
+      const payload = {
         foo: 'bar'
       };
-      var variables = {
+      const variables = {
         someVar: 'someValue'
       };
-      var expected = Object.assign({}, payload, { __var: variables });
-      var rule;
+      const expected = Object.assign({}, payload, { __var: variables });
 
-      spyOn(Engine, 'Rule')
-      .and.returnValue(jasmine.createSpyObj('rule', ['process', 'getSelector']));
       this._engine.insertVars(variables);
-      rule = this._engine.insert('selector', {});
+      const rule = this._engine.insert('selector', {});
       this._engine.process(payload);
+
       expect(rule.process).toHaveBeenCalledWith(jasmine.objectContaining(expected), jasmine.anything());
     });
 
@@ -180,9 +178,9 @@ describe('Engine', function() {
 
   describe('#insert()', function() {
     it('inserts a new Rule', function() {
-      var rule = this._engine.insert('.selector', {});
+      const rule = this._engine.insert('.selector', {});
       expect(rule).toBeDefined();
-      expect(rule).toEqual(jasmine.any(Engine.Rule));
+      expect(rule).toEqual(jasmine.any(Rule));
     });
 
     describe('media queries', function() {


### PR DESCRIPTION
Removed Rule as a static property on the Engine prototype (which seems to have only been there for testing puproses) and fixed up the corresponding tests