### PR TITLE
Refactor: RuleList

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,14 @@ var Focss = Class.extend({
   displayName: 'Focss'
 })
 .mixin({
+  get rules() {
+    return this.engine.getRules();
+  },
+
+  get arrayRuleDescriptors() {
+    return this.engine.getArrayRuleDescriptors();
+  },
+
   get traces() {
     return this.engine.getTraces();
   }

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -1,4 +1,3 @@
-/* global Symbol */
 import Class from 'nbd/Class';
 import RuleList from './RuleList';
 import Style from './Style';
@@ -131,7 +130,6 @@ export default Class.extend({
     }
     else {
       this.style.insertRule(rule.getSelector() + '{}', i);
-      result = true;
     }
 
     if (result) {

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -1,43 +1,30 @@
 /* global Symbol */
 import Class from 'nbd/Class';
-import Rule from './Rule';
+import RuleList from './RuleList';
 import Style from './Style';
 import css from '../util/css';
-import expression from '../util/expression';
 
 function getVendorPrefixRegex() {
-  var otherVendorPrefixesMap = {
+  const otherVendorPrefixesMap = {
     moz: ['webkit', 'ms'],
     webkit: ['moz', 'ms'],
     ms: ['webkit', 'moz'],
   };
-  var ua = navigator.userAgent.toLowerCase();
-  var vendorPrefix = ua.indexOf('trident') > -1 ? 'ms' : (ua.indexOf('webkit') > -1 ? 'webkit' : 'moz');
-  var otherVendorPrefixes = otherVendorPrefixesMap[vendorPrefix];
+  const ua = navigator.userAgent.toLowerCase();
+  const vendorPrefix = ua.indexOf('trident') > -1 ? 'ms' : (ua.indexOf('webkit') > -1 ? 'webkit' : 'moz');
+  const otherVendorPrefixes = otherVendorPrefixesMap[vendorPrefix];
 
   return new RegExp(':-(' + otherVendorPrefixes.join('|') + ')-');
 }
+const hasDom = typeof window !== 'undefined';
+const otherPrefixRegex = hasDom ? getVendorPrefixRegex() : new RegExp();
 
-var hasDom = typeof window !== 'undefined';
-var arrayPropertyRegex = /%([^%]+?)%/g;
-var foreachSelectorRegex = /%forEach\(([^,]+),(.+)\)$/i;
-var filterEachSelectorRegex = /%filterEach\(([^,]+),([^,]+),(.+)\)$/i;
-var mediaQueryRegex = /^@media/;
-var toggleSelectorPsuedoRegex = /:(hover|active)/;
-var toggleSelectorClassRegex = /\.(__[^ :]+)/;
-var otherPrefixRegex = hasDom ? getVendorPrefixRegex() : new RegExp();
-var Engine;
-
-Engine = Class.extend({
+export default Class.extend({
   init(root) {
     this.variables = {};
-    this.rules = [];
-    this.arrayRuleDescriptors = [];
-    this.mediaQueries = [];
     this.extensions = Object.create(this.extensions);
-    this.traces = {};
+    this.rules = new RuleList();
     this._toggleKeys = {};
-    this._uuid = 0;
 
     if (hasDom) {
       this.style = new Style(root);
@@ -45,11 +32,26 @@ Engine = Class.extend({
   },
 
   destroy() {
-    this.rules.length = 0;
-
     if (this.style) {
       this.style.destroy();
     }
+  },
+
+  insert(selector, spec) {
+    // ignore rules that contain the other vendor prefix, as trying to
+    // insert them into a stylesheet will cause an exception to be thrown
+    // @see: http://stackoverflow.com/questions/23050001/insert-multiple-css-rules-into-a-stylesheet
+    if (hasDom && otherPrefixRegex.test(selector)) {
+      return {
+        artifacts: {}
+      };
+    }
+
+    return this.rules.insert(selector, spec);
+  },
+
+  insertVars(spec) {
+    Object.assign(this.variables, spec);
   },
 
   process(payload) {
@@ -58,11 +60,11 @@ Engine = Class.extend({
     }
 
     this._state = Object.assign({}, payload, { __var: this.variables });
-    this._regenerateArrayRules();
-    this.rules.forEach(this._process, this);
+    this.rules.generateArrayRules(this._state, this.extensions);
+    this.rules.getRules().forEach(this._process, this);
 
     // remove leftover rules
-    for (var i = this.style.cssRules.length; i > this.rules.length; i--) {
+    for (let i = this.style.cssRules.length; i > this.rules.getRules().length; i--) {
       this.style.deleteRule(i - 1);
     }
   },
@@ -72,18 +74,18 @@ Engine = Class.extend({
     let mediaQueryResult = '';
 
     this._state = Object.assign({}, payload, { __var: this.variables });
-    this._regenerateArrayRules();
+    this.rules.generateArrayRules(this._state, this.extensions);
 
-    for (let rule of this.rules) {
+    for (let rule of this.rules.getRules()) {
       rule.process(this._getStateWithToggles(), this.extensions);
       result += css.toString(rule.getSelector(), rule.result);
     }
 
-    for (let query of this.mediaQueries) {
-      this._regenerateArrayRules(query);
+    for (let query of this.rules.getMediaQueries()) {
+      query.rules.generateArrayRules(this._state, this.extensions);
       mediaQueryResult += `${query.selector}{`;
 
-      for (let rule of query.rules) {
+      for (let rule of query.rules.getRules()) {
         rule.process(this._getStateWithToggles(), this.extensions);
         mediaQueryResult += css.toString(rule.getSelector(), rule.result);
       }
@@ -95,7 +97,7 @@ Engine = Class.extend({
   },
 
   toggleSelector(key, isToggled) {
-    var isCurrentlyToggled = this._toggleKeys[key] || false;
+    const isCurrentlyToggled = this._toggleKeys[key] || false;
     this._toggleKeys[key] = isToggled;
 
     if (isToggled !== isCurrentlyToggled) {
@@ -103,38 +105,31 @@ Engine = Class.extend({
     }
   },
 
-  _getToggleSelectorInfo(selector) {
-    var toggleKeys = [];
-    var self = this;
-
-    [toggleSelectorPsuedoRegex, toggleSelectorClassRegex].forEach(function(toggleSelectorRegex) {
-      selector = selector.replace(toggleSelectorRegex, function(match, name) {
-        var key = name + (++self._uuid);
-        toggleKeys.push(key);
-        return "${__toggled__['" + key + "']?':not(" + match + ")':'" + match + "'}";
-      });
-    });
-
-    return {
-      selector,
-      toggleKeys
-    };
+  getRules() {
+    return this.rules.getRules();
   },
 
-  _getStateWithToggles() {
-    var state = Object.create(this._state);
-    state.__toggled__ = this._toggleKeys;
+  getArrayRuleDescriptors() {
+    return this.rules.getArrayRuleDescriptors();
+  },
 
-    return state;
+  getTraces() {
+    return this.rules.getTraces();
   },
 
   _process(rule, i) {
-    var result = rule.process(this._getStateWithToggles(), this.extensions);
-    var selector = rule.getSelector();
+    let result = rule.process(this._getStateWithToggles(), this.extensions);
+    const selector = rule.getSelector();
 
-    // Selector has changed
-    if (selector !== this.style.cssRules[i].selectorText) {
-      this.style.deleteRule(i);
+    if (this.style.cssRules[i]) {
+      // Selector has changed
+      if (selector !== this.style.cssRules[i].selectorText) {
+        this.style.deleteRule(i);
+        this.style.insertRule(rule.getSelector() + '{}', i);
+        result = true;
+      }
+    }
+    else {
       this.style.insertRule(rule.getSelector() + '{}', i);
       result = true;
     }
@@ -144,183 +139,11 @@ Engine = Class.extend({
     }
   },
 
-  insert(selector, spec) {
-    if (mediaQueryRegex.test(selector)) {
-      return this._insertMediaQuery(selector, spec);
-    }
+  _getStateWithToggles() {
+    const state = Object.create(this._state);
+    state.__toggled__ = this._toggleKeys;
 
-    return this._insertByType(selector, spec);
-  },
-
-  _insertByType(selector, spec, rulesContext = this) {
-    var expr;
-
-    // ignore rules that contain the other vendor prefix, as trying to
-    // insert them into a stylesheet will cause an exception to be thrown
-    // @see: http://stackoverflow.com/questions/23050001/insert-multiple-css-rules-into-a-stylesheet
-    if (hasDom && otherPrefixRegex.test(selector)) {
-      return {
-        artifacts: {}
-      };
-    }
-
-    expr = foreachSelectorRegex.exec(selector);
-    if (expr !== null) {
-      return this._insertArrayDescriptor(expr[2], expr[1], spec, null, rulesContext);
-    }
-
-    expr = filterEachSelectorRegex.exec(selector);
-    if (expr !== null) {
-      return this._insertArrayDescriptor(expr[3], expr[1], spec, expr[2], rulesContext);
-    }
-
-    return this._insertSingleSelector(selector, spec, rulesContext);
-  },
-
-  insertVars(spec) {
-    Object.assign(this.variables, spec);
-  },
-
-  _insertSingleSelector(insertedSelector, spec, ruleContext) {
-    const { selector, toggleKeys } = this._getToggleSelectorInfo(insertedSelector);
-
-    return this._insertRule({
-      selector,
-      spec,
-      toggleKeys
-    }, ruleContext);
-  },
-
-  _insertMediaQuery(selector, spec) {
-    const descriptor = {
-      selector,
-      rules: [],
-      arrayRuleDescriptors: [],
-      artifacts: {}
-    };
-
-    for (let rule in spec) {
-      let { artifacts } = this._insertByType(rule, spec[rule], descriptor);
-      Object.assign(descriptor.artifacts, artifacts);
-    }
-    this.mediaQueries.push(descriptor);
-
-    return descriptor;
-  },
-
-  _insertArrayDescriptor(selector, expr, spec, filterExpr, rulesContext) {
-    var toggleSelectorInfo = this._getToggleSelectorInfo(selector);
-    var descriptor = {
-      selector: toggleSelectorInfo.selector,
-      expr,
-      spec,
-      filterExpr,
-      toggleKeys: toggleSelectorInfo.toggleKeys,
-      artifacts: this._getArtifactsFromSelector(toggleSelectorInfo.selector)
-    };
-
-    descriptor.artifacts[expr] = true;
-
-    this._generateRulesFromArrayRuleDescriptor(descriptor, rulesContext);
-    rulesContext.arrayRuleDescriptors.push(descriptor);
-
-    return descriptor;
-  },
-
-  _regenerateArrayRules(rulesContext = this) {
-    rulesContext.rules = rulesContext.rules.filter(function(rule) {
-      return !rule.isArrayRule;
-    }, this);
-
-    rulesContext.arrayRuleDescriptors.forEach(function(descriptor) {
-      this._generateRulesFromArrayRuleDescriptor(descriptor, rulesContext);
-    }, this);
-  },
-
-  _getArtifactsFromSelector(selector) {
-    var artifacts = {};
-    var expr;
-
-    while ((expr = Rule.computed.exec(selector)) !== null) {
-      Object.assign(artifacts, expression.parse(expr[1]).artifacts);
-    }
-
-    return artifacts;
-  },
-
-  _generateRulesFromArrayRuleDescriptor(descriptor, ruleContext) {
-    let arrayDataFromState;
-    let filterFunction;
-
-    // occurs when .insert is called before .process
-    if (!this._state) {
-      return;
-    }
-
-    filterFunction = descriptor.filterExpr ? expression.compile(descriptor.filterExpr) : false;
-
-    arrayDataFromState = expression.compile(descriptor.expr)(this._state, this._extensions);
-    arrayDataFromState.forEach((item, index) => {
-      let { selector, spec, toggleKeys } = descriptor;
-
-      // Filtering must happen here instead of a separate filter step to ensure that
-      // `index` is consistent between the data from process and the index provided to _insertRule below
-      if (filterFunction && !filterFunction(item)) {
-        return;
-      }
-
-      let toggleSuffix = '';
-      selector = selector.replace(arrayPropertyRegex, (match, column) => {
-        toggleSuffix += '_' + column + '_' + item[column];
-        return item[column];
-      });
-
-      toggleKeys = toggleKeys.map((toggleKey) => {
-        const newToggleKey = toggleKey + toggleSuffix;
-        selector = selector.replace(`${toggleKey}']?`, `${newToggleKey}']?`);
-        return newToggleKey;
-      });
-
-      this._insertRule({
-        selector,
-        spec,
-        toggleKeys,
-        arrayMemberExpr: `${descriptor.expr}[${index}]`,
-        togglePrefix: `${descriptor.expr}.${index}.`
-      }, ruleContext);
-    });
-  },
-
-  getTraces() {
-    let traces = {};
-
-    for (let rule of this.rules) {
-      for (let key in rule.traces) {
-        if (rule.traces.hasOwnProperty(key)) {
-          traces[key] = rule.traces[key];
-        }
-      }
-    }
-
-    return traces;
-  },
-
-  _insertRule(ruleData, { rules }) {
-    const rule = new Rule(ruleData);
-    const i = this.rules.length;
-
-    if (hasDom) {
-      if (rule.isComputed) {
-        // Placeholder rule
-        this.style.insertRule(':root {}', i);
-      }
-      else {
-        this.style.insertRule(rule.getSelector() + '{}', i);
-      }
-    }
-
-    rules.push(rule);
-    return rule;
+    return state;
   },
 
   extensions: {
@@ -330,24 +153,3 @@ Engine = Class.extend({
 }, {
   displayName: 'FocssEngine'
 });
-
-// ES6 future-proofing
-if (typeof Symbol !== 'undefined' && Symbol.iterator) {
-  Engine.prototype[Symbol.iterator] = function() {
-    return {
-      _keys: this.rules.slice(),
-      next() {
-        var rule;
-        if (rule = this._keys.shift()) {
-          return {
-            value: rule,
-            done: false
-          };
-        }
-        return { done: true };
-      }
-    };
-  };
-}
-
-export default Engine;

--- a/src/RuleList.js
+++ b/src/RuleList.js
@@ -4,7 +4,7 @@ import expression from '../util/expression';
 const foreachSelectorRegex = /%forEach\(([^,]+),(.+)\)$/i;
 const filterEachSelectorRegex = /%filterEach\(([^,]+),([^,]+),(.+)\)$/i;
 const mediaQueryRegex = /^@media/;
-const toggleSelectorPsuedoRegex = /:(hover|active)/;
+const toggleSelectorPseudoRegex = /:(hover|active)/;
 const toggleSelectorClassRegex = /\.(__[^ :]+)/;
 const arrayPropertyRegex = /%([^%]+?)%/g;
 
@@ -96,7 +96,6 @@ export default class RuleList {
       filterExpr,
       toggleKeys: toggleSelectorInfo.toggleKeys,
       artifacts: this._getArtifactsFromSelector(toggleSelectorInfo.selector),
-      isArrayDescriptor: true
     };
 
     descriptor.artifacts[expr] = true;
@@ -118,7 +117,7 @@ export default class RuleList {
   _getToggleSelectorInfo(selector) {
     const toggleKeys = [];
 
-    [toggleSelectorPsuedoRegex, toggleSelectorClassRegex].forEach((toggleSelectorRegex) => {
+    [toggleSelectorPseudoRegex, toggleSelectorClassRegex].forEach((toggleSelectorRegex) => {
       selector = selector.replace(toggleSelectorRegex, (match, name) => {
         const key = name + (++this._uuid);
         toggleKeys.push(key);
@@ -158,7 +157,7 @@ export default class RuleList {
 
       let toggleSuffix = '';
       selector = selector.replace(arrayPropertyRegex, (match, column) => {
-        toggleSuffix += '_' + column + '_' + item[column];
+        toggleSuffix += `_${column}_${item[column]}`;
         return item[column];
       });
 

--- a/src/RuleList.js
+++ b/src/RuleList.js
@@ -1,0 +1,186 @@
+import Rule from './Rule';
+import expression from '../util/expression';
+
+const foreachSelectorRegex = /%forEach\(([^,]+),(.+)\)$/i;
+const filterEachSelectorRegex = /%filterEach\(([^,]+),([^,]+),(.+)\)$/i;
+const mediaQueryRegex = /^@media/;
+const toggleSelectorPsuedoRegex = /:(hover|active)/;
+const toggleSelectorClassRegex = /\.(__[^ :]+)/;
+const arrayPropertyRegex = /%([^%]+?)%/g;
+
+export default class RuleList {
+  constructor() {
+    this.rules = [];
+    this.arrayRuleDescriptors = [];
+    this.mediaQueries = [];
+    this._uuid = 0;
+  }
+
+  getRules() {
+    return this.rules;
+  }
+
+  getArrayRuleDescriptors() {
+    return this.arrayRuleDescriptors;
+  }
+
+  getMediaQueries() {
+    return this.mediaQueries;
+  }
+
+  getTraces() {
+    let traces = {};
+
+    for (let rule of this.rules) {
+      for (let key in rule.traces) {
+        if (rule.traces.hasOwnProperty(key)) {
+          traces[key] = rule.traces[key];
+        }
+      }
+    }
+
+    return traces;
+  }
+
+  generateArrayRules(state, extensions) {
+    this.rules = this.rules.filter(rule => !rule.isArrayRule);
+
+    this.arrayRuleDescriptors.forEach((descriptor) => {
+      this._generateRulesFromArrayRuleDescriptor(descriptor, state, extensions);
+    });
+  }
+
+  insert(selector, spec) {
+    let expr;
+
+    if (mediaQueryRegex.test(selector)) {
+      return this._insertMediaQuery(selector, spec);
+    }
+
+    expr = foreachSelectorRegex.exec(selector);
+    if (expr !== null) {
+      return this._insertArrayDescriptor(expr[2], expr[1], spec);
+    }
+
+    expr = filterEachSelectorRegex.exec(selector);
+    if (expr !== null) {
+      return this._insertArrayDescriptor(expr[3], expr[1], spec, expr[2]);
+    }
+
+    return this._insertSingleSelector(selector, spec);
+  }
+
+  _insertMediaQuery(selector, spec) {
+    const descriptor = {
+      selector,
+      rules: new RuleList(),
+      arrayRuleDescriptors: [],
+      artifacts: {}
+    };
+
+    for (let rule in spec) {
+      const { artifacts } = descriptor.rules.insert(rule, spec[rule]);
+      Object.assign(descriptor.artifacts, artifacts);
+    }
+    this.mediaQueries.push(descriptor);
+
+    return descriptor;
+  }
+
+  _insertArrayDescriptor(selector, expr, spec, filterExpr) {
+    const toggleSelectorInfo = this._getToggleSelectorInfo(selector);
+    const descriptor = {
+      selector: toggleSelectorInfo.selector,
+      expr,
+      spec,
+      filterExpr,
+      toggleKeys: toggleSelectorInfo.toggleKeys,
+      artifacts: this._getArtifactsFromSelector(toggleSelectorInfo.selector),
+      isArrayDescriptor: true
+    };
+
+    descriptor.artifacts[expr] = true;
+    this.arrayRuleDescriptors.push(descriptor);
+
+    return descriptor;
+  }
+
+  _insertSingleSelector(insertedSelector, spec) {
+    const { selector, toggleKeys } = this._getToggleSelectorInfo(insertedSelector);
+
+    return this._insert({
+      selector,
+      spec,
+      toggleKeys
+    });
+  }
+
+  _getToggleSelectorInfo(selector) {
+    const toggleKeys = [];
+
+    [toggleSelectorPsuedoRegex, toggleSelectorClassRegex].forEach((toggleSelectorRegex) => {
+      selector = selector.replace(toggleSelectorRegex, (match, name) => {
+        const key = name + (++this._uuid);
+        toggleKeys.push(key);
+        return "${__toggled__['" + key + "']?':not(" + match + ")':'" + match + "'}";
+      });
+    });
+
+    return {
+      selector,
+      toggleKeys
+    };
+  }
+
+  _getArtifactsFromSelector(selector) {
+    const artifacts = {};
+    let expr;
+
+    while ((expr = Rule.computed.exec(selector)) !== null) {
+      Object.assign(artifacts, expression.parse(expr[1]).artifacts);
+    }
+
+    return artifacts;
+  }
+
+  _generateRulesFromArrayRuleDescriptor(descriptor, state, extensions) {
+    let arrayDataFromState;
+    let filterFunction;
+
+    filterFunction = descriptor.filterExpr ? expression.compile(descriptor.filterExpr) : false;
+    arrayDataFromState = expression.compile(descriptor.expr)(state, extensions);
+    return arrayDataFromState.forEach((item, index) => {
+      let { selector, spec, toggleKeys } = descriptor;
+
+      if (filterFunction && !filterFunction(item)) {
+        return;
+      }
+
+      let toggleSuffix = '';
+      selector = selector.replace(arrayPropertyRegex, (match, column) => {
+        toggleSuffix += '_' + column + '_' + item[column];
+        return item[column];
+      });
+
+      toggleKeys = toggleKeys.map((toggleKey) => {
+        const newToggleKey = toggleKey + toggleSuffix;
+        selector = selector.replace(`${toggleKey}']?`, `${newToggleKey}']?`);
+        return newToggleKey;
+      });
+
+      this._insert({
+        selector,
+        spec,
+        toggleKeys,
+        arrayMemberExpr: `${descriptor.expr}[${index}]`,
+        togglePrefix: `${descriptor.expr}.${index}.`
+      });
+    });
+  }
+
+  _insert(ruleData) {
+    const rule = new Rule(ruleData);
+    this.rules.push(rule);
+    return rule;
+  }
+}

--- a/test/behavior/dynamic.js
+++ b/test/behavior/dynamic.js
@@ -22,17 +22,17 @@ describe('dynamic rules', function() {
         'max-width': 'width'
       });
 
-      expect(fox.engine.rules.arrayRuleDescriptors.length).toBe(1);
-      expect(fox.engine.rules.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
+      expect(fox.engine.getArrayRuleDescriptors().length).toBe(1);
+      expect(fox.engine.rules.getArrayRuleDescriptors()[0].artifacts).toEqual({ foo: true });
     });
 
     it('filterEach contains the correct artifacts', function() {
-      fox.insert('%forEach(foo, true, .bar[data-id="%id%"])', {
+      fox.insert('%filterEach(foo, true, .bar[data-id="%id%"])', {
         'max-width': 'width'
       });
 
-      expect(fox.engine.rules.arrayRuleDescriptors.length).toBe(1);
-      expect(fox.engine.rules.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
+      expect(fox.engine.rules.getArrayRuleDescriptors().length).toBe(1);
+      expect(fox.engine.rules.getArrayRuleDescriptors()[0].artifacts).toEqual({ foo: true });
     });
   });
 

--- a/test/behavior/dynamic.js
+++ b/test/behavior/dynamic.js
@@ -16,14 +16,14 @@ describe('dynamic rules', function() {
     fox = null;
   });
 
-  describe('engine.arrayRuleDescriptors', function() {
+  describe('arrayRuleDescriptors', function() {
     it('forEach contains the correct artifacts', function() {
       fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
         'max-width': 'width'
       });
 
-      expect(fox.engine.arrayRuleDescriptors.length).toBe(1);
-      expect(fox.engine.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
+      expect(fox.engine.rules.arrayRuleDescriptors.length).toBe(1);
+      expect(fox.engine.rules.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
     });
 
     it('filterEach contains the correct artifacts', function() {
@@ -31,8 +31,8 @@ describe('dynamic rules', function() {
         'max-width': 'width'
       });
 
-      expect(fox.engine.arrayRuleDescriptors.length).toBe(1);
-      expect(fox.engine.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
+      expect(fox.engine.rules.arrayRuleDescriptors.length).toBe(1);
+      expect(fox.engine.rules.arrayRuleDescriptors[0].artifacts).toEqual({ foo: true });
     });
   });
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -14,7 +14,7 @@ describe('Focss', function() {
     }
   });
 
-  it('is instanciable', function() {
+  it('is instantiable', function() {
     let fox;
 
     expect(() => {
@@ -89,6 +89,56 @@ describe('Focss', function() {
   describe('#destroy()', function() {
     it('exists', function() {
       expect(this._fox.destroy).toEqual(jasmine.any(Function));
+    });
+  });
+
+  describe('get rules', function() {
+    beforeEach(function() {
+      this._fox.insert('.foo', {
+        width: 'bar'
+      });
+    });
+
+    it('returns list of rules', function() {
+      expect(this._fox.rules).toEqual([jasmine.objectContaining({
+        selector: '.foo',
+        artifacts: {
+          bar: true
+        }
+      })]);
+    });
+  });
+
+  describe('get arrayRuleDescriptors', function() {
+    beforeEach(function() {
+      this._fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
+        width: 'baz'
+      });
+    });
+
+    it('returns list of rules', function() {
+      expect(this._fox.arrayRuleDescriptors).toEqual([jasmine.objectContaining({
+        selector: ' .bar[data-id="%id%"]',
+        artifacts: {
+          foo: true
+        }
+      })]);
+    });
+  });
+
+  describe('get arrayRuleDescriptors', function() {
+    beforeEach(function() {
+      this._fox.insert('foo:hover', {
+        width: 'bar'
+      });
+    });
+
+    it('returns list of rules', function() {
+      expect(this._fox.traces).toEqual({
+        hover1: {
+          bar: true
+        }
+      });
     });
   });
 });

--- a/test/unit/src/Engine.js
+++ b/test/unit/src/Engine.js
@@ -61,8 +61,8 @@ describe('Engine', function() {
         color: '__var.bar'
       });
       this._engine.process({ dynamic: 'foobar' });
-      expect(this._engine.rules[0].computedSelector).toBe('.container');
-      expect(this._engine.rules[0].artifacts).toEqual({
+      expect(this._engine.rules.getRules()[0].computedSelector).toBe('.container');
+      expect(this._engine.rules.getRules()[0].artifacts).toEqual({
         dynamic: true,
         '__var.foo': true,
         '__var.bar': true
@@ -197,12 +197,12 @@ describe('Engine', function() {
       });
 
       it('inserts a media query rule', function() {
-        expect(this._engine.mediaQueries[0]).toBeDefined();
-        expect(this._engine.mediaQueries.length).toEqual(1);
+        expect(this._engine.rules.getMediaQueries()[0]).toBeDefined();
+        expect(this._engine.rules.getMediaQueries().length).toEqual(1);
       });
 
       it('contains the correct artifacts', function() {
-        expect(this._engine.mediaQueries[0].artifacts).toEqual({
+        expect(this._engine.rules.getMediaQueries()[0].artifacts).toEqual({
           foo: true,
           bar: true,
           baz: true

--- a/test/unit/src/Engine.js
+++ b/test/unit/src/Engine.js
@@ -23,6 +23,14 @@ describe('Engine', function() {
     engine.destroy();
   });
 
+  describe('#insert()', function() {
+    it('inserts a new Rule', function() {
+      const rule = this._engine.insert('.selector', {});
+      expect(rule).toBeDefined();
+      expect(rule).toEqual(jasmine.any(Rule));
+    });
+  });
+
   describe('#process()', function() {
     it('runs individual rule.process()', function() {
       spyOn(Rule.prototype, 'process');
@@ -173,41 +181,6 @@ describe('Engine', function() {
     it('it does not run rule.process() if the keys value is falsey and has not been set before', function() {
       this._engine.toggleSelector('newkey2', false);
       expect(this._engine.process).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('#insert()', function() {
-    it('inserts a new Rule', function() {
-      const rule = this._engine.insert('.selector', {});
-      expect(rule).toBeDefined();
-      expect(rule).toEqual(jasmine.any(Rule));
-    });
-
-    describe('media queries', function() {
-      beforeEach(function() {
-        this._engine.insert('@media screen and (max-width: 300px)', {
-          '.class1': {
-            width: 'foo',
-            color: 'bar'
-          },
-          '%forEach(baz, .class2[data-id="%id%"])': {
-            'max-width': 'qux'
-          }
-        });
-      });
-
-      it('inserts a media query rule', function() {
-        expect(this._engine.rules.getMediaQueries()[0]).toBeDefined();
-        expect(this._engine.rules.getMediaQueries().length).toEqual(1);
-      });
-
-      it('contains the correct artifacts', function() {
-        expect(this._engine.rules.getMediaQueries()[0].artifacts).toEqual({
-          foo: true,
-          bar: true,
-          baz: true
-        });
-      });
     });
   });
 });

--- a/test/unit/src/RuleList.js
+++ b/test/unit/src/RuleList.js
@@ -1,0 +1,286 @@
+import RuleList from '../../../src/RuleList';
+
+describe('RuleList', function() {
+  beforeEach(function() {
+    this._rules = new RuleList();
+  });
+
+  afterEach(function() {
+    this._rules = null;
+  });
+
+  it('is a constructor', function() {
+    let rules;
+
+    expect(function() {
+      rules = new RuleList();
+    }).not.toThrow();
+    expect(rules).toBeDefined();
+  });
+
+  describe('#getRules', function() {
+    it('returns list of rule descriptors', function() {
+      const rules = ['foo', 'bar'];
+      this._rules.rules = rules;
+      expect(this._rules.rules).toEqual(rules);
+    });
+  });
+
+  describe('#getArrayRuleDescriptors', function() {
+    it('returns list of array rule descriptors', function() {
+      const arrayRules = ['foo', 'bar'];
+      this._rules.arrayRuleDescriptors = arrayRules;
+      expect(this._rules.getArrayRuleDescriptors()).toEqual(arrayRules);
+    });
+  });
+
+  describe('#getMediaQueries', function() {
+    it('returns list of media query descriptors', function() {
+      const mediaQueryRules = ['foo', 'bar'];
+      this._rules.mediaQueries = mediaQueryRules;
+      expect(this._rules.getMediaQueries()).toEqual(mediaQueryRules);
+    });
+  });
+
+  describe('#getTraces', function() {
+    it('returns traces from inserted rule descriptors', function() {
+      this._rules.insert('.foo:hover', {
+        width: 'baz'
+      });
+      this._rules.insert('.bar:hover', {
+        width: 'qux'
+      });
+
+      expect(this._rules.getTraces()).toEqual({
+        hover1: {
+          baz: true
+        },
+        hover2: {
+          qux: true
+        }
+      });
+    });
+
+    it('returns empty object if no traces exist', function() {
+      this._rules.insert('.foo', {
+        width: 'baz'
+      });
+      this._rules.insert('.bar', {
+        width: 'qux'
+      });
+
+      expect(this._rules.getTraces()).toEqual({});
+    });
+  });
+
+  describe('#generateArrayRules', function() {
+    beforeEach(function() {
+      this._rules.insert('%forEach(foo, .bar[data-id="%id%"])', {
+        width: 'baz'
+      });
+
+      expect(this._rules.rules.length).toEqual(0);
+      this._rules.generateArrayRules({
+        foo: [
+          { id: 1, baz: 100 },
+          { id: 2, baz: 200 },
+          { id: 3, baz: 300 }
+        ]
+      });
+    });
+
+    it('generates array rules', function() {
+      expect(this._rules.rules.length).toEqual(3);
+      expect(this._rules.rules).toEqual([
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="1"]',
+        }),
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="2"]',
+        }),
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="3"]',
+        }),
+      ]);
+    });
+
+    it('regenerates all previously generated array rules', function() {
+      this._rules.generateArrayRules({
+        foo: [
+          { id: 3, baz: 100 },
+          { id: 4, baz: 200 },
+          { id: 5, baz: 300 }
+        ]
+      });
+
+      expect(this._rules.rules.length).toEqual(3);
+      expect(this._rules.rules).toEqual([
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="3"]',
+        }),
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="4"]',
+        }),
+        jasmine.objectContaining({
+          selector: ' .bar[data-id="5"]',
+        }),
+      ]);
+    });
+  });
+
+  describe('#insert', function() {
+    describe('media queries', function() {
+      beforeEach(function() {
+        this._rules.insert('@media screen and (max-width: 300px)', {
+          '.class1': {
+            width: 'foo',
+            color: 'bar'
+          },
+          '%forEach(baz, .class2[data-id="%id%"])': {
+            'max-width': 'qux'
+          }
+        });
+      });
+
+      it('inserts a media query rule', function() {
+        expect(this._rules.mediaQueries[0]).toBeDefined();
+        expect(this._rules.mediaQueries.length).toEqual(1);
+      });
+
+      it('contains the correct artifacts', function() {
+        expect(this._rules.mediaQueries[0].artifacts).toEqual({
+          foo: true,
+          bar: true,
+          baz: true
+        });
+      });
+    });
+
+    describe('%forEach', function() {
+      beforeEach(function() {
+        this._rules.insert('%forEach(foo, .bar[data-id="%id%"])', {
+          width: 'baz'
+        });
+      });
+
+      it('inserts a rule descriptor with a %forEach selector', function() {
+        expect(this._rules.arrayRuleDescriptors).toBeDefined();
+        expect(this._rules.arrayRuleDescriptors.length).toEqual(1);
+      });
+
+      it('contains the correct artifacts', function() {
+        expect(this._rules.arrayRuleDescriptors[0].artifacts).toEqual({
+          foo: true
+        });
+      });
+    });
+
+    describe('%filterEach', function() {
+      beforeEach(function() {
+        this._rules.insert('%filterEach(foo, baz > 100, .bar[data-id="%id%"])', {
+          width: 'baz'
+        });
+      });
+
+      it('inserts a rule descriptor with a %filterEach selector', function() {
+        expect(this._rules.arrayRuleDescriptors).toBeDefined();
+        expect(this._rules.arrayRuleDescriptors.length).toEqual(1);
+      });
+
+      it('contains the correct artifacts', function() {
+        expect(this._rules.arrayRuleDescriptors[0].artifacts).toEqual({
+          foo: true
+        });
+      });
+    });
+
+    describe('static selectors', function() {
+      beforeEach(function() {
+        this._rules.insert('.foo', {
+          width: 'bar'
+        });
+      });
+
+      it('inserts a rule descriptor with a static selector', function() {
+        expect(this._rules.rules).toBeDefined();
+        expect(this._rules.rules.length).toEqual(1);
+      });
+
+      it('contains the correct artifacts', function() {
+        expect(this._rules.rules[0].artifacts).toEqual({
+          bar: true
+        });
+      });
+    });
+
+    describe('toggle selectors', function() {
+      it('inserts a rule descriptor with a toggle selector', function() {
+        this._rules.insert('.foo.__fake', {
+          width: 'bar'
+        });
+
+        expect(this._rules.rules).toBeDefined();
+        expect(this._rules.rules.length).toEqual(1);
+      });
+
+      describe('toggle selector classes', function() {
+        beforeEach(function() {
+          this._rules.insert('.foo.__fake', {
+            width: 'bar'
+          });
+        });
+
+        it('creates toggle selector', function() {
+          expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['__fake1']?':not(.__fake)':'.__fake'}");
+        });
+
+        it('contains the correct artifacts', function() {
+          expect(this._rules.rules[0].artifacts).toEqual({
+            bar: true,
+            '__toggled__.__fake1': true
+          });
+        });
+      });
+
+      describe('toggle selector pseudo classes', function() {
+        describe(':hover', function() {
+          beforeEach(function() {
+            this._rules.insert('.foo:hover', {
+              width: 'bar'
+            });
+          });
+
+          it('creates toggle selector', function() {
+            expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['hover1']?':not(:hover)':':hover'}");
+          });
+
+          it('contains the correct artifacts', function() {
+            expect(this._rules.rules[0].artifacts).toEqual({
+              bar: true,
+              '__toggled__.hover1': true
+            });
+          });
+        });
+
+        describe(':active', function() {
+          beforeEach(function() {
+            this._rules.insert('.foo:active', {
+              width: 'bar'
+            });
+          });
+
+          it('creates toggle selector', function() {
+            expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['active1']?':not(:active)':':active'}");
+          });
+
+          it('contains the correct artifacts', function() {
+            expect(this._rules.rules[0].artifacts).toEqual({
+              bar: true,
+              '__toggled__.active1': true
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
I split the tests up into their own commit because this got kind of big.

All the tests are passing in the first commit - I just wanted to add more unit tests for extra confidence/documentation for others.

The big thing this achieves is that `Engine` is now responsible for processing rules and managing the stylesheet, and `RuleList` is responsible for the logic of inserting rules.

Removing the auto-processing on insert in my previous PR means that inserting rules no longer has to add placeholder rules to the stylesheet - instead, we insert the rules into the stylesheet on `process` after we have already generated all the rules.

**TL;DR**: `insert`ing rules only adds them to the internally managed rule list, while calling `process` or `toString` takes data, generates all the rules, and manages the removal/insertion into the stylesheet or returns a string of the generated styles, respectively.