### PR TITLE
Deprecate old computed selector delimiter

### DIFF
--- a/src/RuleBase.js
+++ b/src/RuleBase.js
@@ -1,7 +1,7 @@
 import diff from 'nbd/util/diff';
 import expression from './util/expression';
 
-export const computedExpression = /\$\{([^\}]*?)\}|<%\s*(.*?)\s*%>/ig;
+export const computedExpression = /<%\s*(.*?)\s*%>/ig;
 
 export default class RuleBase {
   getSelector() {
@@ -35,7 +35,7 @@ export default class RuleBase {
     // contain *multiple* template strings in a row.
     while ((expr = computedExpression.exec(selector)) !== null) {
       isComputed = true;
-      Object.assign(artifacts, expression.parse(expr[1] || expr[2]).artifacts);
+      Object.assign(artifacts, expression.parse(expr[1]).artifacts);
     }
 
     return { isComputed, artifacts };
@@ -45,10 +45,7 @@ export default class RuleBase {
     let selector = this.selector;
 
     if (this.isComputed) {
-      selector = this.selector.replace(computedExpression, (match, oldExpr, newExpr) => {
-        const expr = oldExpr || newExpr;
-        return expression.compile(expr)(data, extensions);
-      });
+      selector = this.selector.replace(computedExpression, (match, expr) => expression.compile(expr)(data, extensions));
     }
 
     this.computedSelector = selector;

--- a/src/RuleList.js
+++ b/src/RuleList.js
@@ -8,7 +8,7 @@ const filterEachSelectorRegex = /%filterEach\(([^,]+),([^,]+),(.+)\)$/i;
 const mediaQueryRegex = /^@media/;
 const toggleSelectorPseudoRegex = /:(hover|active)/;
 const toggleSelectorClassRegex = /\.(__[^ :]+)/;
-const arrayPropertyRegex = /%([^%]+?)%/g;
+const arrayPropertyRegex = /([^<])%(?!>)(.+?)%(?!>)/g;
 
 export default class RuleList {
   constructor() {
@@ -112,7 +112,7 @@ export default class RuleList {
       selector = selector.replace(toggleSelectorRegex, (match, name) => {
         const key = name + (++this._uuid);
         toggleKeys.push(key);
-        return "${__toggled__['" + key + "']?':not(" + match + ")':'" + match + "'}";
+        return `<%__toggled__['${key}']?':not(${match})':'${match}'%>`;
       });
     });
 
@@ -147,9 +147,10 @@ export default class RuleList {
       }
 
       let toggleSuffix = '';
-      selector = selector.replace(arrayPropertyRegex, (match, column) => {
+      selector = selector.replace(arrayPropertyRegex, (match, firstChar, column) => {
         toggleSuffix += `_${column}_${item[column]}`;
-        return item[column];
+        // The first character is captured and replaced as a workaround for JS not having regex lookbehinds
+        return `${firstChar}${item[column]}`;
       });
 
       toggleKeys = toggleKeys.map((toggleKey) => {

--- a/test/behavior/dynamic.js
+++ b/test/behavior/dynamic.js
@@ -342,7 +342,7 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector that has a computed target selector', function() {
-        var artifacts = fox.insert('%filterEach(foo, type === "form", .${ classPrefix + classSuffix }[data-id="%id%"])', {
+        var artifacts = fox.insert('%filterEach(foo, type === "form", .<% classPrefix + classSuffix %>[data-id="%id%"])', {
           'max-width': 'width'
         });
 
@@ -425,7 +425,7 @@ describe('dynamic rules', function() {
     it('has no effect without calling process', function() {
       var el = affix('div.bar');
 
-      fox.insert('.${foo}', {
+      fox.insert('.<% foo %>', {
         'max-width': 'width'
       });
 
@@ -436,7 +436,7 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.${foo}', {
+      artifacts = fox.insert('.<% foo %>', {
         'max-width': 'width'
       });
       fox.process({ foo: 'bar', width: 100 });
@@ -449,7 +449,7 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.${foo.baz}', {
+      artifacts = fox.insert('.<% foo.baz %>', {
         'max-width': 'width'
       });
       fox.process({ foo: { baz: 'bar' }, width: 100 });
@@ -462,7 +462,7 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.${foo}${baz}', {
+      artifacts = fox.insert('.<% foo %><% baz %>', {
         'max-width': 'width'
       });
       fox.process({ foo: 'ba', baz: 'r', width: 100 });
@@ -473,7 +473,7 @@ describe('dynamic rules', function() {
 
     it('removes styles when selector no longer matches', function() {
       var el = affix('div.bar');
-      fox.insert('.${foo}', {
+      fox.insert('.<% foo %>', {
         'max-width': 'width'
       });
 
@@ -486,7 +486,7 @@ describe('dynamic rules', function() {
 
     it('maintains styles when selector changes', function() {
       var el = affix('div.bar.baz');
-      fox.insert('.${foo}', {
+      fox.insert('.<% foo %>', {
         'max-width': 'width'
       });
 

--- a/test/unit/src/Engine.js
+++ b/test/unit/src/Engine.js
@@ -64,7 +64,7 @@ describe('Engine', function() {
         foo: '.container',
         bar: 'red'
       });
-      this._engine.insert('${__var.foo}', {
+      this._engine.insert('<% __var.foo %>', {
         width: 'dynamic',
         color: '__var.bar'
       });

--- a/test/unit/src/Rule.js
+++ b/test/unit/src/Rule.js
@@ -109,7 +109,7 @@ describe('Rule', function() {
   it('accepts expressions in selectors', function() {
     expect(function() {
       rule = new Rule({
-        selector: '#${foo}',
+        selector: '#<% foo %>',
         spec: {}
       });
     }).not.toThrow();
@@ -146,7 +146,7 @@ describe('Rule', function() {
 
     it('calculates computed selectors', function() {
       rule = new Rule({
-        selector: '.${dynamic}',
+        selector: '.<% dynamic %>',
         spec: {}
       });
       rule.process({ dynamic: 'foobar' });

--- a/test/unit/src/RuleList.js
+++ b/test/unit/src/RuleList.js
@@ -237,7 +237,7 @@ describe('RuleList', function() {
         });
 
         it('creates toggle selector', function() {
-          expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['__fake1']?':not(.__fake)':'.__fake'}");
+          expect(this._rules.rules[0].selector).toEqual(".foo<%__toggled__['__fake1']?':not(.__fake)':'.__fake'%>");
         });
 
         it('contains the correct artifacts', function() {
@@ -257,7 +257,7 @@ describe('RuleList', function() {
           });
 
           it('creates toggle selector', function() {
-            expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['hover1']?':not(:hover)':':hover'}");
+            expect(this._rules.rules[0].selector).toEqual(".foo<%__toggled__['hover1']?':not(:hover)':':hover'%>");
           });
 
           it('contains the correct artifacts', function() {
@@ -276,7 +276,7 @@ describe('RuleList', function() {
           });
 
           it('creates toggle selector', function() {
-            expect(this._rules.rules[0].selector).toEqual(".foo${__toggled__['active1']?':not(:active)':':active'}");
+            expect(this._rules.rules[0].selector).toEqual(".foo<%__toggled__['active1']?':not(:active)':':active'%>");
           });
 
           it('contains the correct artifacts', function() {


### PR DESCRIPTION
For context - JS expressions that need to be computed in Focss selectors used to be denoted by `${ }`. I have since converted over all the Focss descriptors to the new `<% %>` delimiters, and can now remove the backwards compatibility.