### PR TITLE
Remove ability to insert descriptors as strings/objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,28 +11,19 @@ export default class {
    * @param spec {Object|null} key/value map of CSS property to expression or null if selector is object or array
    * @returns Object Artifacts found while compiling the rule
    */
-  insert(selector, spec) {
-    if (typeof selector === 'object') {
-      const artifacts = {};
-
-      if (Array.isArray(selector)) {
-        for (let s of selector) {
-          Object.assign(artifacts, this.insert(s.selector, s.rules));
-        }
-      }
-      else {
-        for (let s in selector) {
-          if (selector.hasOwnProperty(s)) {
-            Object.assign(artifacts, this.insert(s, selector[s]));
-          }
-        }
-      }
-
-      return artifacts;
+  insert(descriptors) {
+    if (!Array.isArray(descriptors)) {
+      throw new TypeError('Inserted descriptors must be an array.');
     }
 
-    const { artifacts } = this.engine.insert(selector, spec);
-    return artifacts;
+    const artifactsMap = {};
+
+    for (const { selector, rules } of descriptors) {
+      const { artifacts } = this.engine.insert(selector, rules);
+      Object.assign(artifactsMap, artifacts);
+    }
+
+    return artifactsMap;
   }
 
   toggleSelector(key, isToggled) {

--- a/test/behavior/defaultExtensions.js
+++ b/test/behavior/defaultExtensions.js
@@ -19,9 +19,14 @@ describe('default extensions', function() {
 
   describe('Math', function() {
     it('.floor', function() {
-      fox.insert('.foo', {
-        'max-width': 'Math.floor(width)'
-      });
+      fox.insert([
+        {
+          selector: '.foo',
+          rules: {
+            'max-width': 'Math.floor(width)'
+          }
+        }
+      ]);
 
       fox.process({
         width: 100.6
@@ -33,9 +38,14 @@ describe('default extensions', function() {
 
   describe('Number', function() {
     it('.parseInt', function() {
-      fox.insert('.foo', {
-        'max-width': 'Number.parseInt(width)'
-      });
+      fox.insert([
+        {
+          selector: '.foo',
+          rules: {
+            'max-width': 'Number.parseInt(width)'
+          }
+        }
+      ]);
 
       fox.process({
         width: '123'

--- a/test/behavior/dynamic.js
+++ b/test/behavior/dynamic.js
@@ -18,18 +18,28 @@ describe('dynamic rules', function() {
 
   describe('arrayRuleDescriptors', function() {
     it('forEach contains the correct artifacts', function() {
-      fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '%forEach(foo, .bar[data-id="%id%"])',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(fox.engine.getArrayRuleDescriptors().length).toBe(1);
       expect(fox.engine.rules.getArrayRuleDescriptors()[0].artifacts).toEqual({ foo: true });
     });
 
     it('filterEach contains the correct artifacts', function() {
-      fox.insert('%filterEach(foo, true, .bar[data-id="%id%"])', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '%filterEach(foo, true, .bar[data-id="%id%"])',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(fox.engine.rules.getArrayRuleDescriptors().length).toBe(1);
       expect(fox.engine.rules.getArrayRuleDescriptors()[0].artifacts).toEqual({ foo: true });
@@ -46,18 +56,28 @@ describe('dynamic rules', function() {
 
     describe('insert/process call ordering', function() {
       it('has no effect when insert is called without calling process', function() {
-        var artifacts = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         expect(css(this._el, 'max-width')).toBe('none');
         expect(artifacts).toEqual({ foo: true });
       });
 
       it('evaluates the selector multiple times when process is called multiple times', function() {
-        const artifacts = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        const artifacts = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -93,9 +113,14 @@ describe('dynamic rules', function() {
 
     describe('when process is called', function() {
       it('can evaluate selector with a comma in the target selector', function() {
-        var artifacts = fox.insert('%forEach(foo, .baz[data-id="%id%"], .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%forEach(foo, .baz[data-id="%id%"], .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -112,9 +137,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with a closing parens in the target selector', function() {
-        var artifacts = fox.insert('%forEach(foo, .bar[data-id="%id%"]:nth-child(odd))', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"]:nth-child(odd))',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -131,9 +161,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with nested property lookup from spec', function() {
-        var artifacts  = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'data.width'
-        });
+        var artifacts  = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'data.width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -148,9 +183,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with missing property lookup from spec', function() {
-        var artifacts  = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts  = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -165,9 +205,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with extension use in the spec', function() {
-        var artifacts  = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'Math.floor(width)'
-        });
+        var artifacts  = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'Math.floor(width)'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -182,9 +227,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with expressions from spec', function() {
-        var artifacts  = fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-          'max-width': 'width + padding'
-        });
+        var artifacts  = fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width + padding'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -200,9 +250,14 @@ describe('dynamic rules', function() {
 
       // TODO: when the use case is required, allow for nested missing property lookup
       xit('can evaluate selector with nested missing property lookup from spec', function() {
-        var artifacts = fox.insert('%forEach(foo.baz, .bar[data-id="%id%"])', {
-          'max-width': 'data.width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%forEach(foo.baz, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'data.width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: {
@@ -219,9 +274,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector with nested array lookup', function() {
-        var artifacts = fox.insert('%forEach(foo.baz, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%forEach(foo.baz, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: {
@@ -249,14 +309,24 @@ describe('dynamic rules', function() {
           }
         };
 
-        fox.insert('%forEach(foo.baz, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        fox.insert([
+          {
+            selector: '%forEach(foo.baz, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         fox.process(data);
 
-        fox.insert('.my-rule', {
-          width: 'foo.width'
-        });
+        fox.insert([
+          {
+            selector: '.my-rule',
+            rules: {
+              width: 'foo.width'
+            }
+          }
+        ]);
         fox.process(data);
 
         expect(css(this._el, 'max-width')).toBe('100px');
@@ -276,18 +346,28 @@ describe('dynamic rules', function() {
 
     describe('insert/process call ordering', function() {
       it('has no effect when insert is called without calling process', function() {
-        var artifacts = fox.insert('%filterEach(foo, true, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, true, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         expect(css(this._el, 'max-width')).toBe('none');
         expect(artifacts).toEqual({ foo: true });
       });
 
       it('evaluates the selector multiple times when process is called multiple times', function() {
-        const artifacts = fox.insert('%filterEach(foo, true, .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        const artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, true, .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -323,9 +403,14 @@ describe('dynamic rules', function() {
 
     describe('when process is called', function() {
       it('can evaluate selector with a comma in the target selector', function() {
-        var artifacts = fox.insert('%filterEach(foo, true, .baz[data-id="%id%"], .bar[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, true, .baz[data-id="%id%"], .bar[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -342,9 +427,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selector that has a computed target selector', function() {
-        var artifacts = fox.insert('%filterEach(foo, type === "form", .<% classPrefix + classSuffix %>[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, type === "form", .<% classPrefix + classSuffix %>[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           classPrefix: 'b',
@@ -363,9 +453,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selectors with a truthy filter value', function() {
-        var artifacts = fox.insert('%filterEach(foo, true, div[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, true, div[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -382,9 +477,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selectors with a falsey filter value', function() {
-        var artifacts = fox.insert('%filterEach(foo, false, div[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, false, div[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -401,9 +501,14 @@ describe('dynamic rules', function() {
       });
 
       it('can evaluate selectors with a complex filter value', function() {
-        var artifacts = fox.insert('%filterEach(foo, width > 200, div[data-id="%id%"])', {
-          'max-width': 'width'
-        });
+        var artifacts = fox.insert([
+          {
+            selector: '%filterEach(foo, width > 200, div[data-id="%id%"])',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
 
         fox.process({
           foo: [
@@ -425,9 +530,14 @@ describe('dynamic rules', function() {
     it('has no effect without calling process', function() {
       var el = affix('div.bar');
 
-      fox.insert('.<% foo %>', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '.<% foo %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(css(el, 'max-width')).toBe('none');
     });
@@ -436,9 +546,14 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.<% foo %>', {
-        'max-width': 'width'
-      });
+      artifacts = fox.insert([
+        {
+          selector: '.<% foo %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
       fox.process({ foo: 'bar', width: 100 });
 
       expect(css(el, 'max-width')).toBe('100px');
@@ -449,9 +564,14 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.<% foo.baz %>', {
-        'max-width': 'width'
-      });
+      artifacts = fox.insert([
+        {
+          selector: '.<% foo.baz %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
       fox.process({ foo: { baz: 'bar' }, width: 100 });
 
       expect(css(el, 'max-width')).toBe('100px');
@@ -462,9 +582,14 @@ describe('dynamic rules', function() {
       var el = affix('div.bar');
       var artifacts;
 
-      artifacts = fox.insert('.<% foo %><% baz %>', {
-        'max-width': 'width'
-      });
+      artifacts = fox.insert([
+        {
+          selector: '.<% foo %><% baz %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
       fox.process({ foo: 'ba', baz: 'r', width: 100 });
 
       expect(css(el, 'max-width')).toBe('100px');
@@ -473,9 +598,14 @@ describe('dynamic rules', function() {
 
     it('removes styles when selector no longer matches', function() {
       var el = affix('div.bar');
-      fox.insert('.<% foo %>', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '.<% foo %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       fox.process({ foo: 'bar', width: 100 });
       expect(css(el, 'max-width')).toBe('100px');
@@ -486,9 +616,14 @@ describe('dynamic rules', function() {
 
     it('maintains styles when selector changes', function() {
       var el = affix('div.bar.baz');
-      fox.insert('.<% foo %>', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '.<% foo %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       fox.process({ foo: 'bar', width: 100 });
       expect(css(el, 'max-width')).toBe('100px');
@@ -500,9 +635,14 @@ describe('dynamic rules', function() {
 
   describe('DOM mutation', function() {
     beforeEach(function() {
-      fox.insert('.bar', {
-        'max-width': 'width'
-      });
+      fox.insert([
+        {
+          selector: '.bar',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
     });
 
     // Stuff that depends on MutationObserver are very tricky to time
@@ -529,7 +669,14 @@ describe('dynamic rules', function() {
     });
 
     it('affects descendants when ancestors\' attributes change', function() {
-      fox.insert('.bar .stool', { 'max-height': 'width' });
+      fox.insert([
+        {
+          selector: '.bar .stool',
+          rules: {
+            'max-height': 'width'
+          }
+        }
+      ]);
       fox.process({ width: 100 });
 
       var el = affix('.baz .stool');

--- a/test/behavior/pseudo.js
+++ b/test/behavior/pseudo.js
@@ -22,7 +22,14 @@ describe('positional pseudo class selectors', function() {
       var first = ul.find('li:first-child');
       var second = first.next();
       var last = second.next();
-      fox.insert('li:first-child', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:first-child',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(first, 'max-width')).toBe('100px');
@@ -35,7 +42,14 @@ describe('positional pseudo class selectors', function() {
       var first = ul.find('li:first-child');
       var second = first.next();
       var last = second.next();
-      fox.insert('li:first-child', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:first-child',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].insertBefore(second[0], first[0]);
@@ -52,7 +66,14 @@ describe('positional pseudo class selectors', function() {
       var last = ul.find('li:last-child');
       var second = last.prev();
       var first = second.prev();
-      fox.insert('li:last-child', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:last-child',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(last, 'max-width')).toBe('100px');
@@ -65,7 +86,14 @@ describe('positional pseudo class selectors', function() {
       var last = ul.find('li:last-child');
       var second = last.prev();
       var first = second.prev();
-      fox.insert('li:last-child', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:last-child',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].appendChild(second[0]);
@@ -81,7 +109,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('span:first-of-type'));
 
-      fox.insert('span:first-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'span:first-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(target, 'max-width')).toBe('100px');
@@ -92,7 +127,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('span:first-of-type'));
 
-      fox.insert('span:first-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'span:first-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       var span = document.createElement('span');
@@ -108,7 +150,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('span:last-of-type'));
 
-      fox.insert('span:last-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'span:last-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(target.siblings().css('max-width')).toBe('none');
@@ -118,7 +167,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('span:last-of-type'));
 
-      fox.insert('span:last-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'span:last-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       var span = document.createElement('span');
@@ -134,7 +190,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('div:only-of-type'));
 
-      fox.insert('div:only-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'div:only-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(target, 'max-width')).toBe('100px');
@@ -145,7 +208,14 @@ describe('positional pseudo class selectors', function() {
       var ul = affix('section div+span+span+h1');
       var target = $(ul[0].querySelector('div:only-of-type'));
 
-      fox.insert('div:only-of-type', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'div:only-of-type',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(target, 'max-width')).toBe('100px');
@@ -161,7 +231,14 @@ describe('positional pseudo class selectors', function() {
     it('affects only the nth element', function() {
       var ul = affix('ul li+li+li+li');
 
-      fox.insert('li:nth-child(2n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-child(2n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(ul.find('li:eq(0)'), 'max-width')).toBe('none');
@@ -173,7 +250,14 @@ describe('positional pseudo class selectors', function() {
     it('tracks when new element shifts positions', function() {
       var ul = affix('ul li+li+li+li');
 
-      fox.insert('li:nth-child(2n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-child(2n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].insertBefore(document.createElement('li'), ul[0].childNodes[0]);
@@ -188,7 +272,14 @@ describe('positional pseudo class selectors', function() {
     it('tracks when removing element shifts positions', function() {
       var ul = affix('ul li+li+li+li');
 
-      fox.insert('li:nth-child(3n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-child(3n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].removeChild(ul[0].firstChild);
@@ -201,7 +292,14 @@ describe('positional pseudo class selectors', function() {
     it('tracks when positions shift', function() {
       var ul = affix('ul li#first+li#second+li#third+li#last');
 
-      fox.insert('li:nth-child(2n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-child(2n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].insertBefore(ul[0].childNodes[1], ul[0].childNodes[0]);
@@ -217,7 +315,14 @@ describe('positional pseudo class selectors', function() {
     it('affects only the nth element in reverse', function() {
       var ul = affix('ul li+li+li+li');
 
-      fox.insert('li:nth-last-child(2n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-last-child(2n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(ul.find('li:eq(0)'), 'max-width')).toBe('100px');
@@ -229,7 +334,14 @@ describe('positional pseudo class selectors', function() {
     it('tracks when new element shifts positions', function() {
       var ul = affix('ul li+li+li+li');
 
-      fox.insert('li:nth-last-child(2n)', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'li:nth-last-child(2n)',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       ul[0].appendChild(document.createElement('li'));
@@ -257,7 +369,14 @@ describe('relational pseudo class selectors', function() {
     it('matches only empty elements', function() {
       var ul = affix('ul');
 
-      fox.insert('ul:empty', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'ul:empty',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(ul, 'max-width')).toBe('100px');
@@ -304,7 +423,14 @@ describe('input pseudo class selectors', function() {
     it('matches enabled inputs', function() {
       var input = affix('input[type=text]');
 
-      fox.insert('input:enabled', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'input:enabled',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(input, 'max-width')).toBe('100px');
@@ -318,7 +444,14 @@ describe('input pseudo class selectors', function() {
     it('matches disabled inputs', function() {
       var input = affix('input[type=text]');
 
-      fox.insert('input:disabled', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'input:disabled',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(input, 'max-width')).toBe('none');
@@ -332,7 +465,14 @@ describe('input pseudo class selectors', function() {
     it('matches checked inputs', function() {
       var input = affix('input[type=checkbox]');
 
-      fox.insert('input:checked', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'input:checked',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(input, 'max-width')).toBe('none');
@@ -346,7 +486,14 @@ describe('input pseudo class selectors', function() {
     it('matches indeterminate inputs', function() {
       var input = affix('input[type=checkbox]');
 
-      fox.insert('input:indeterminate', { 'max-width': 'foo' });
+      fox.insert([
+        {
+          selector: 'input:indeterminate',
+          rules: {
+            'max-width': 'foo'
+          }
+        }
+      ]);
       fox.process({ foo: 100 });
 
       expect(css(input, 'max-width')).toBe('none');
@@ -371,7 +518,14 @@ describe('pseudo elements', function() {
     it('sets pseudo element content', function() {
       var el = affix('div');
 
-      fox.insert('div:before', { content: 'foo' });
+      fox.insert([
+        {
+          selector: 'div:before',
+          rules: {
+            content: 'foo'
+          }
+        }
+      ]);
       expect(css(el, 'content', ':before')).not.toBe('bar');
 
       fox.process({ foo: '"bar"' });
@@ -382,7 +536,14 @@ describe('pseudo elements', function() {
     it('sets pseudo element content', function() {
       var el = affix('div');
 
-      fox.insert('div:after', { content: 'foo' });
+      fox.insert([
+        {
+          selector: 'div:after',
+          rules: {
+            content: 'foo'
+          }
+        }
+      ]);
       expect(css(el, 'content', ':after')).not.toBe('bar');
 
       fox.process({ foo: '"bar"' });

--- a/test/behavior/static.js
+++ b/test/behavior/static.js
@@ -5,9 +5,14 @@ function insertSpecs(selector) {
   it(selector + ' affects existing elements', function() {
     affix(selector);
 
-    fox.insert(selector, {
-      'max-width': 'width'
-    });
+    fox.insert([
+      {
+        selector,
+        rules: {
+          'max-width': 'width'
+        }
+      }
+    ]);
 
     fox.process({ width: 100 });
 
@@ -15,9 +20,14 @@ function insertSpecs(selector) {
   });
 
   it(selector + ' affects new elements', function() {
-    fox.insert(selector, {
-      'max-width': 'width'
-    });
+    fox.insert([
+      {
+        selector,
+        rules: {
+          'max-width': 'width'
+        }
+      }
+    ]);
 
     fox.process({ width: 100 });
 
@@ -29,18 +39,28 @@ function insertSpecs(selector) {
   it(selector + ' affects existing elements with newly inserted and processed rule', function() {
     affix(selector);
 
-    fox.insert(selector, {
-      'max-width': 'width'
-    });
+    fox.insert([
+      {
+        selector,
+        rules: {
+          'max-width': 'width'
+        }
+      }
+    ]);
     fox.process({ width: 100 });
 
     expect($(selector).css('max-width')).toBe('100px');
   });
 
   it(selector + ' affects new elements with newly inserted and processed rule', function() {
-    fox.insert(selector, {
-      'max-width': 'width'
-    });
+    fox.insert([
+      {
+        selector,
+        rules: {
+          'max-width': 'width'
+        }
+      }
+    ]);
     fox.process({ width: 100 });
 
     affix(selector);
@@ -97,9 +117,14 @@ describe('static rules', function() {
       var selector = 'input';
       var $el = affix(selector);
       var oldValue = $el.css('fontSize');
-      var artifacts = fox.insert('input, input::-' + incorrectPrefix + '-input-placeholder', {
-        'font-size': 'size'
-      });
+      var artifacts = fox.insert([
+        {
+          selector: 'input, input::-' + incorrectPrefix + '-input-placeholder',
+          rules: {
+            'font-size': 'size'
+          }
+        }
+      ]);
 
       fox.process({ size: '20px' });
 

--- a/test/behavior/toString.js
+++ b/test/behavior/toString.js
@@ -12,22 +12,33 @@ describe('Focss#toString', function() {
 
   describe('returns a string of processed styles', function() {
     it('when inserted rule contains single selector', function() {
-      this._fox.insert('.foo', {
-        'max-width': 'width'
-      });
+      this._fox.insert([
+        {
+          selector: '.foo',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(this._fox.toString({ width: 100 })).toEqual('.foo{max-width:100px;}');
     });
 
     it('when inserted rule contains %forEach selector', function() {
-      this._fox.insert({
-        '.baz': {
-          width: 'width'
+      this._fox.insert([
+        {
+          selector: '.baz',
+          rules: {
+            width: 'width'
+          }
         },
-        '%forEach(foo, .bar[data-id="%id%"])': {
-          'max-width': 'maxWidth'
+        {
+          selector: '%forEach(foo, .bar[data-id="%id%"])',
+          rules: {
+            'max-width': 'maxWidth'
+          }
         }
-      });
+      ]);
 
       expect(this._fox.toString({
         width: 400,
@@ -39,14 +50,20 @@ describe('Focss#toString', function() {
     });
 
     it('when inserted rule contains %filterEach selector', function() {
-      this._fox.insert({
-        '.baz': {
-          width: 'width'
+      this._fox.insert([
+        {
+          selector: '.baz',
+          rules: {
+            width: 'width'
+          }
         },
-        '%filterEach(foo, true, .bar[data-id="%id%"])': {
-          'max-width': 'width'
+        {
+          selector: '%filterEach(foo, true, .bar[data-id="%id%"])',
+          rules: {
+            'max-width': 'width'
+          }
         }
-      });
+      ]);
 
       expect(this._fox.toString({
         width: 400,
@@ -58,17 +75,20 @@ describe('Focss#toString', function() {
     });
 
     it('when inserted rule contains media query', function() {
-      this._fox.insert({
-        '@media screen and (max-width: 300px)': [
-          {
-            selector: '.class1',
-            rules: {
-              width: 'foo',
-              color: 'bar'
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: 300px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo',
+                color: 'bar'
+              }
             }
-          }
-        ]
-      });
+          ]
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 100,
@@ -77,8 +97,223 @@ describe('Focss#toString', function() {
     });
 
     it('when inserted media query contains %forEach selector', function() {
-      this._fox.insert({
-        '@media screen and (max-width: 300px)': [
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: 300px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo',
+                color: 'bar'
+              }
+            }
+          ]
+        },
+        {
+          selector: '%forEach(baz, .class2[data-id="%id%"])',
+          rules: {
+            'max-width': 'qux'
+          }
+        }
+      ]);
+
+      expect(this._fox.toString({
+        foo: 100,
+        bar: 'red',
+        baz: [
+          { id: 3, qux: 1200 },
+          { id: 4, qux: 800 }
+        ]
+      })).toEqual('.class2[data-id="3"]{max-width:1200px;}.class2[data-id="4"]{max-width:800px;}@media screen and (max-width: 300px){.class1{width:100px;color:red;}}');
+    });
+
+    it('when inserted media query contains %filterEach selector', function() {
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: 300px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo',
+                color: 'bar'
+              }
+            }
+          ]
+        },
+        {
+          selector: '%filterEach(baz, qux < 1000, .class2[data-id="%id%"])',
+          rules: {
+            'max-width': 'qux'
+          }
+        }
+      ]);
+
+      expect(this._fox.toString({
+        foo: 100,
+        bar: 'red',
+        baz: [
+          { id: 3, qux: 1200 },
+          { id: 4, qux: 800 }
+        ]
+      })).toEqual('.class2[data-id="4"]{max-width:800px;}@media screen and (max-width: 300px){.class1{width:100px;color:red;}}');
+    });
+
+    it('when inserted media query contains computed selector', function() {
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: <% baz + qux %>px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo'
+              }
+            },
+            {
+              selector: '.class2',
+              rules: {
+                color: 'bar'
+              }
+            }
+          ]
+        }
+      ]);
+
+      expect(this._fox.toString({
+        foo: 100,
+        bar: 'red',
+        baz: 200,
+        qux: 1600
+      })).toEqual('@media screen and (max-width: 1800px){.class1{width:100px;}.class2{color:red;}}');
+    });
+
+    it('when inserted rule list contains multiple media queries', function() {
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: 300px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo'
+              }
+            }
+          ]
+        }
+      ]);
+      this._fox.insert([
+        {
+          selector: '@media screen and (max-width: 600px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                color: 'bar'
+              }
+            }
+          ]
+        }
+      ]);
+
+      expect(this._fox.toString({
+        foo: 100,
+        bar: 'red'
+      })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;}}@media screen and (max-width: 600px){.class1{color:red;}}');
+    });
+
+    it('when inserted rule list contains a mixture of non-media query and media query rules', function() {
+      this._fox.insert([
+        {
+          selector: '.class1',
+          rules: {
+            'max-width': 'foo'
+          }
+        },
+        {
+          selector: '@media screen and (max-width: 300px)',
+          rules: [
+            {
+              selector: '.class1',
+              rules: {
+                width: 'foo',
+                color: 'bar'
+              }
+            }
+          ]
+        }
+      ]);
+
+      expect(this._fox.toString({
+        foo: 100,
+        bar: 'red'
+      })).toEqual('.class1{max-width:100px;}@media screen and (max-width: 300px){.class1{width:100px;color:red;}}');
+    });
+  });
+
+  it('returns media queries in order in which they were inserted', function() {
+    this._fox.insert([
+      {
+        selector: '@media screen and (max-width: 300px)',
+        rules: [
+          {
+            selector: '.class1',
+            rules: {
+              width: 'foo'
+            }
+          }
+        ]
+      }
+    ]);
+    this._fox.insert([
+      {
+        selector: '@media screen and (max-width: 600px)',
+        rules: [
+          {
+            selector: '.class1',
+            rules: {
+              color: 'bar'
+            }
+          }
+        ]
+      }
+    ]);
+    this._fox.insert([
+      {
+        selector: '@media screen and (max-width: 100px)',
+        rules: [
+          {
+            selector: '.class1',
+            rules: {
+              height: 'baz'
+            }
+          }
+        ]
+      }
+    ]);
+
+    expect(this._fox.toString({
+      foo: 100,
+      bar: 'red',
+      baz: 600
+    })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;}}@media screen and (max-width: 600px){.class1{color:red;}}@media screen and (max-width: 100px){.class1{height:600px;}}');
+  });
+
+  it('returns non-media query rules before media query rules regardless of order inserted', function() {
+    this._fox.insert([
+      {
+        selector: '.class1',
+        rules: {
+          color: 'bar'
+        }
+      }
+    ]);
+
+    this._fox.insert([
+      {
+        selector: '@media screen and (max-width: 300px)',
+        rules: [
           {
             selector: '.class1',
             rules: {
@@ -93,193 +328,17 @@ describe('Focss#toString', function() {
             }
           }
         ]
-      });
+      }
+    ]);
 
-      expect(this._fox.toString({
-        foo: 100,
-        bar: 'red',
-        baz: [
-          { id: 3, qux: 1200 },
-          { id: 4, qux: 800 }
-        ]
-      })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;color:red;}.class2[data-id="3"]{max-width:1200px;}.class2[data-id="4"]{max-width:800px;}}');
-    });
-
-    it('when inserted media query contains %filterEach selector', function() {
-      this._fox.insert({
-        '@media screen and (max-width: 300px)': [
-          {
-            selector: '.class1',
-            rules: {
-              width: 'foo',
-              color: 'bar'
-            }
-          },
-          {
-            selector: '%filterEach(baz, qux < 1000, .class2[data-id="%id%"])',
-            rules: {
-              'max-width': 'qux'
-            }
-          }
-        ]
-      });
-
-      expect(this._fox.toString({
-        foo: 100,
-        bar: 'red',
-        baz: [
-          { id: 3, qux: 1200 },
-          { id: 4, qux: 800 }
-        ]
-      })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;color:red;}.class2[data-id="4"]{max-width:800px;}}');
-    });
-
-    it('when inserted media query contains computed selector', function() {
-      this._fox.insert({
-        '@media screen and (max-width: <% baz + qux %>px)': [
-          {
-            selector: '.class1',
-            rules: {
-              width: 'foo'
-            }
-          },
-          {
-            selector: '.class2',
-            rules: {
-              color: 'bar'
-            }
-          }
-        ]
-      });
-
-      expect(this._fox.toString({
-        foo: 100,
-        bar: 'red',
-        baz: 200,
-        qux: 1600
-      })).toEqual('@media screen and (max-width: 1800px){.class1{width:100px;}.class2{color:red;}}');
-    });
-
-    it('when inserted rule list contains multiple media queries', function() {
-      this._fox.insert({
-        '@media screen and (max-width: 300px)': [
-          {
-            selector: '.class1',
-            rules: {
-              width: 'foo'
-            }
-          }
-        ]
-      });
-      this._fox.insert({
-        '@media screen and (max-width: 600px)': [
-          {
-            selector: '.class1',
-            rules: {
-              color: 'bar'
-            }
-          }
-        ]
-      });
-
-      expect(this._fox.toString({
-        foo: 100,
-        bar: 'red'
-      })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;}}@media screen and (max-width: 600px){.class1{color:red;}}');
-    });
-
-    it('when inserted rule list contains a mixture of non-media query and media query rules', function() {
-      this._fox.insert({
-        '.class1': {
+    this._fox.insert([
+      {
+        selector: '.class2',
+        rules: {
           'max-width': 'foo'
-        },
-        '@media screen and (max-width: 300px)': [
-          {
-            selector: '.class1',
-            rules: {
-              width: 'foo',
-              color: 'bar'
-            }
-          }
-        ]
-      });
-
-      expect(this._fox.toString({
-        foo: 100,
-        bar: 'red'
-      })).toEqual('.class1{max-width:100px;}@media screen and (max-width: 300px){.class1{width:100px;color:red;}}');
-    });
-  });
-
-  it('returns media queries in order in which they were inserted', function() {
-    this._fox.insert({
-      '@media screen and (max-width: 300px)': [
-        {
-          selector: '.class1',
-          rules: {
-            width: 'foo'
-          }
         }
-      ]
-    });
-    this._fox.insert({
-      '@media screen and (max-width: 600px)': [
-        {
-          selector: '.class1',
-          rules: {
-            color: 'bar'
-          }
-        }
-      ]
-    });
-    this._fox.insert({
-      '@media screen and (max-width: 100px)': [
-        {
-          selector: '.class1',
-          rules: {
-            height: 'baz'
-          }
-        }
-      ]
-    });
-
-    expect(this._fox.toString({
-      foo: 100,
-      bar: 'red',
-      baz: 600
-    })).toEqual('@media screen and (max-width: 300px){.class1{width:100px;}}@media screen and (max-width: 600px){.class1{color:red;}}@media screen and (max-width: 100px){.class1{height:600px;}}');
-  });
-
-  it('returns non-media query rules before media query rules regardless of order inserted', function() {
-    this._fox.insert({
-      '.class1': {
-        color: 'bar'
       }
-    });
-
-    this._fox.insert({
-      '@media screen and (max-width: 300px)': [
-        {
-          selector: '.class1',
-          rules: {
-            width: 'foo',
-            color: 'bar'
-          }
-        },
-        {
-          selector: '%forEach(baz, .class2[data-id="%id%"])',
-          rules: {
-            'max-width': 'qux'
-          }
-        }
-      ]
-    });
-
-    this._fox.insert({
-      '.class2': {
-        'max-width': 'foo'
-      }
-    });
+    ]);
 
     expect(this._fox.toString({
       foo: 100,
@@ -293,9 +352,14 @@ describe('Focss#toString', function() {
 
   describe('`<% %>` delimiter', function() {
     it('works when used in a an attribute selector', function() {
-      this._fox.insert('.<% foo %>[<% bar %>]', {
-        'max-width': 'width'
-      });
+      this._fox.insert([
+        {
+          selector: '.<% foo %>[<% bar %>]',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 'a',
@@ -305,9 +369,14 @@ describe('Focss#toString', function() {
     });
 
     it('correctly evaulates a JavaScript expression', function() {
-      this._fox.insert('.<% foo || bar %>', {
-        'max-width': 'width'
-      });
+      this._fox.insert([
+        {
+          selector: '.<% foo || bar %>',
+          rules: {
+            'max-width': 'width'
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 'a',
@@ -316,9 +385,14 @@ describe('Focss#toString', function() {
     });
 
     it('correctly evaulates a JavaScript expression', function() {
-      this._fox.insert('.<% foo || bar %>', {
-        'max-width': 'width',
-      });
+      this._fox.insert([
+        {
+          selector: '.<% foo || bar %>',
+          rules: {
+            'max-width': 'width',
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         bar: 'b',
@@ -327,9 +401,14 @@ describe('Focss#toString', function() {
     });
 
     it('correctly evaulates a JavaScript expression with a < symbol', function() {
-      this._fox.insert('.class<% foo < bar ? foo : bar %>', {
-        'max-width': 'width',
-      });
+      this._fox.insert([
+        {
+          selector: '.class<% foo < bar ? foo : bar %>',
+          rules: {
+            'max-width': 'width',
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 4,
@@ -339,9 +418,14 @@ describe('Focss#toString', function() {
     });
 
     it('correctly evaulates a JavaScript expression with a < and % symbol', function() {
-      this._fox.insert('.class<% foo < bar % 5 ? foo % 3 : bar %>', {
-        'max-width': 'width',
-      });
+      this._fox.insert([
+        {
+          selector: '.class<% foo < bar % 5 ? foo % 3 : bar %>',
+          rules: {
+            'max-width': 'width',
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 4,
@@ -351,9 +435,14 @@ describe('Focss#toString', function() {
     });
 
     it('correctly evaulates a computed expression regardless of surrounding whitespace', function() {
-      this._fox.insert('.<%foo  %>', {
-        'max-width': 'width',
-      });
+      this._fox.insert([
+        {
+          selector: '.<%foo  %>',
+          rules: {
+            'max-width': 'width',
+          }
+        }
+      ]);
 
       expect(this._fox.toString({
         foo: 'a',

--- a/test/behavior/toggleSelectors.js
+++ b/test/behavior/toggleSelectors.js
@@ -18,9 +18,14 @@ describe('toggleSelectors rules', function() {
     describe('with a single psuedo selector', function() {
       beforeEach(function() {
         this._el = affix('div.bar');
-        this._fox.insert('.bar:hover', {
-          'max-width': 'width'
-        });
+        this._fox.insert([
+          {
+            selector: '.bar:hover',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         this._fox.process({
           width: 20,
           foo: 'foo'
@@ -49,9 +54,14 @@ describe('toggleSelectors rules', function() {
     describe('with multiple psuedo selector', function() {
       beforeEach(function() {
         this._el = affix('div.bar');
-        this._fox.insert('.bar:hover, .bar:active', {
-          'max-width': 'width'
-        });
+        this._fox.insert([
+          {
+            selector: '.bar:hover, .bar:active',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         this._fox.process({
           width: 20,
           foo: 'foo'
@@ -80,9 +90,14 @@ describe('toggleSelectors rules', function() {
     describe('with togglable class selector', function() {
       beforeEach(function() {
         this._el = affix('div.bar.__sent');
-        this._fox.insert('.bar.__sent', {
-          'max-width': 'width'
-        });
+        this._fox.insert([
+          {
+            selector: '.bar.__sent',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         this._fox.process({
           width: 20,
           foo: 'foo'
@@ -111,9 +126,14 @@ describe('toggleSelectors rules', function() {
     describe('with togglable class selector with psuedo element', function() {
       beforeEach(function() {
         this._el = affix('div.bar.__sent');
-        this._fox.insert('.bar.__sent:before', {
-          'max-width': 'width'
-        });
+        this._fox.insert([
+          {
+            selector: '.bar.__sent:before',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         this._fox.process({
           width: 20,
           foo: 'foo'
@@ -147,9 +167,14 @@ describe('toggleSelectors rules', function() {
 
     describe('with a forEach selector', function() {
       beforeEach(function() {
-        this._fox.insert('%forEach(foo, .bar[data-id="%id%"]:hover)', {
-          'max-width': 'width'
-        });
+        this._fox.insert([
+          {
+            selector: '%forEach(foo, .bar[data-id="%id%"]:hover)',
+            rules: {
+              'max-width': 'width'
+            }
+          }
+        ]);
         this._fox.process({
           foo: [
             { id: -1, width: 100 },

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -27,42 +27,7 @@ describe('Focss', function() {
   });
 
   describe('#insert()', function() {
-    it('inserts single rules', function() {
-      spyOn(this._fox.engine, 'insert').and.returnValue({});
-
-      this._fox.insert('.selector', {
-        prop: ''
-      });
-      expect(this._fox.engine.insert)
-      .toHaveBeenCalledWith('.selector', jasmine.objectContaining({
-        prop: ''
-      }));
-    });
-
-    it('inserts a spec of rules from an object', function() {
-      spyOn(this._fox.engine, 'insert').and.returnValue({});
-
-      this._fox.insert({
-        '.selector': {
-          prop: ''
-        },
-        '.selector2': {
-          otherProp: ''
-        }
-      });
-
-      expect(this._fox.engine.insert.calls.count()).toEqual(2);
-      expect(this._fox.engine.insert.calls.allArgs()).toEqual([
-        ['.selector', jasmine.objectContaining({
-          prop: ''
-        })],
-        ['.selector2', jasmine.objectContaining({
-          otherProp: ''
-        })]
-      ]);
-    });
-
-    it('inserts a spec of rules from an array', function() {
+    it('inserts a spec of descriptors from an array', function() {
       spyOn(this._fox.engine, 'insert').and.returnValue({});
 
       this._fox.insert([
@@ -90,6 +55,20 @@ describe('Focss', function() {
         })]
       ]);
     });
+
+    it('should throw an error when inserted descriptors are not an array', function() {
+      expect(() => {
+        this._fox.insert('.selector{width:foo;}');
+      }).toThrow(new TypeError('Inserted descriptors must be an array.'));
+
+      expect(() => {
+        this._fox.insert({
+          '.selector': {
+            prop: ''
+          }
+        });
+      }).toThrow(new TypeError('Inserted descriptors must be an array.'));
+    });
   });
 
   describe('#process()', function() {
@@ -108,9 +87,14 @@ describe('Focss', function() {
         b: 200
       };
 
-      this._fox.insert('.foo', {
-        'max-width': 'a + b'
-      });
+      this._fox.insert([
+        {
+          selector: '.foo',
+          rules: {
+            'max-width': 'a + b'
+          }
+        }
+      ]);
       expect(this._fox.toString(payload)).toEqual('.foo{max-width:300px;}');
     });
   });
@@ -132,9 +116,14 @@ describe('Focss', function() {
 
   describe('get rules', function() {
     beforeEach(function() {
-      this._fox.insert('.foo', {
-        width: 'bar'
-      });
+      this._fox.insert([
+        {
+          selector: '.foo',
+          rules: {
+            width: 'bar'
+          }
+        }
+      ]);
     });
 
     it('returns list of rules', function() {
@@ -149,9 +138,14 @@ describe('Focss', function() {
 
   describe('get arrayRuleDescriptors', function() {
     beforeEach(function() {
-      this._fox.insert('%forEach(foo, .bar[data-id="%id%"])', {
-        width: 'baz'
-      });
+      this._fox.insert([
+        {
+          selector: '%forEach(foo, .bar[data-id="%id%"])',
+          rules: {
+            width: 'baz'
+          }
+        }
+      ]);
     });
 
     it('returns list of rules', function() {
@@ -166,9 +160,14 @@ describe('Focss', function() {
 
   describe('get arrayRuleDescriptors', function() {
     beforeEach(function() {
-      this._fox.insert('foo:hover', {
-        width: 'bar'
-      });
+      this._fox.insert([
+        {
+          selector: 'foo:hover',
+          rules: {
+            width: 'bar'
+          }
+        }
+      ]);
     });
 
     it('returns list of rules', function() {


### PR DESCRIPTION
We now ONLY insert descriptors as arrays, since we always want to ensure order.